### PR TITLE
Submit form on button press, enter key

### DIFF
--- a/br-webui/views/git.liquid
+++ b/br-webui/views/git.liquid
@@ -260,14 +260,14 @@ gitsetup.emit('authenticated?');
 
 
 <!--- Get Github Credentials --->
-<div id="authenticate" style="display: none">
+<form id="authenticate" style="display: none" onsubmit="authenticate(); return false">
 	<h1>Authentication Required</h1>
 	<span>github username</span>
 	<input class="form-control" id="username" style="width: 200px;" />
 	<span>github password</span>
 	<input class="form-control" id="password" type="password" style="width: 200px;" />
-	<input type="submit" class="btn btn-primary" value="Authenticate" onClick="authenticate()"/>
-</div>
+	<input type="submit" class="btn btn-primary" value="Authenticate"/>
+</form>
 
 
 <!--- Main Content --->
@@ -286,11 +286,11 @@ gitsetup.emit('authenticated?');
 					<h1>Current HEAD:</h1>
 					<h3 id="HEAD label"><h3>
 					<h1>Add new remote</h1>
-					<div class="form-group">
+					<form class="form-group" onsubmit="addRemote(); return false">
 						<input class="form-control" id="new remote name" style="width: 400px;" />
 						<input class="form-control" id="new remote url" style="width: 400px;" value="ssh://git@github.com/bluerobotics/repository.git" />
-						<input type="submit" class="btn btn-primary" value="Add New Remote" onClick="addRemote()" />
-					</div>
+						<input type="submit" class="btn btn-primary" value="Add New Remote" />
+					</form>
 					<h1>remotelist</h1>
 					<input type="submit" class="btn btn-primary" value="Checkout" onClick="checkoutCompanion()"/>
 					<input type="submit" class="btn btn-primary" value="Fetch" onClick="fetchCompanion()"/>

--- a/br-webui/views/index.liquid
+++ b/br-webui/views/index.liquid
@@ -95,14 +95,16 @@ setInterval(function() {
 				<h3 class="panel-title">Wifi Setup</h3>
 			</div>
 			<div class="panel-body">
-				<h3>Wifi SSID:</h3>
-				<select class="form-control" id="ssid" style="width: 200px;"></select>
-				<h3>Password:</h3>
-				<div class="form-group">
-					<input class="form-control" id="password" type="password" style="width: 200px;" />
-					<button id="joinButton" type="button" class="btn btn-primary" onclick="joinNetwork()">Join Network</button>
-					<i id="spinner" class="fa fa-refresh fa-spin fa-2x fa-fw" style="visibility:hidden"></i>
-				</div>
+				<form onsubmit="joinNetwork(); return false">
+					<h3>Wifi SSID:</h3>
+					<select class="form-control" id="ssid" style="width: 200px;"></select>
+					<h3>Password:</h3>
+					<div class="form-group">
+						<input class="form-control" id="password" type="password" style="width: 200px;" />
+						<button id="joinButton" type="submit" class="btn btn-primary">Join Network</button>
+						<i id="spinner" class="fa fa-refresh fa-spin fa-2x fa-fw" style="visibility:hidden"></i>
+					</div>
+				</form>
 			</div>
 		</div>
 	</div>

--- a/br-webui/views/routing.liquid
+++ b/br-webui/views/routing.liquid
@@ -224,7 +224,7 @@
 				<h3 class="panel-title">Create Serial Endpoint</h3>
 			</div>
 			<div class="panel-body">
-				<div id="serialConfig">
+				<form id="serialConfig" onsubmit="addSerialEndpoint(); return false">
 					<div class="form-group">
 						<label>Serial Port:</label>
 						<select class="form-control" id="serialPorts"></select>
@@ -233,8 +233,8 @@
 						<label>Baud Rate:</label>
 						<input type="text" class="form-control" id="baudrate" />
 					</div>
-					<button type="button" class="btn btn-primary" onclick="addSerialEndpoint()" >Add Serial Endpoint</button>
-				</div>
+					<button type="submit" class="btn btn-primary">Add Serial Endpoint</button>
+				</form>
 			</div>
 		</div>
 	</div>
@@ -244,7 +244,7 @@
 				<h3 class="panel-title">Create UDP Endpoint</h3>
 			</div>
 			<div class="panel-body">
-				<div id="udpConfig">
+				<form id="udpConfig" onsubmit="addUDPEndpoint(); return false">
 					<div class="form-group">
 						<label>UDP IP Address:</label>
 						<input type="text" class="form-control" id="udpIP"></input>
@@ -253,8 +253,8 @@
 						<label>UDP Port:</label>
 						<input type="text" class="form-control" id="udpPort"></input>
 					</div>
-					<button type="button" class="btn btn-primary" onclick="addUDPEndpoint()">Add UDP Endpoint</button>
-				</div>
+					<button type="submit" class="btn btn-primary">Add UDP Endpoint</button>
+				</form>
 			</div>
 		</div>
 	</div>
@@ -267,7 +267,7 @@
 				<h3 class="panel-title">Create Routes</h3>
 			</div>
 			<div class="panel-body">
-				<form class="form-inline">
+				<form class="form-inline" onsubmit="connect(); return false">
 					<div class="form-group">
 						<select class="form-control" id="source"></select>
 						<select class="form-control" id="direction">
@@ -277,7 +277,7 @@
 						</select>
 						<select class="form-control" id="target"></select>
 					</div>
-					<button type="button" class="btn btn-primary" onclick="connect()">Connect</button>
+					<button type="submit" class="btn btn-primary">Connect</button>
 				</form>
 			</div>
 		</div>


### PR DESCRIPTION
Most text inputs can now be submitted with the enter key in addition to pressing the submit button.

The main exception is the /waterlinked page, for which there would be no visual feedback when the enter key was pressed.  This could be problematic as multiple instances of the Water Linked driver can be opened, creating the potential for silently overwhelming and crashing the companion computer.  Thus the "Start Water Linked Driver" button must be pressed to start the Water Linked driver.

Closes #47 