### PR TITLE
Print parameter name only once

### DIFF
--- a/tools/flashPXParameters.py
+++ b/tools/flashPXParameters.py
@@ -62,9 +62,9 @@ with open(filename,'r') as f:
 		verified = False
 		attempts = 0
 		
-		while not verified and attempts < 3:
-			print "Sending " + name + " = " + str(value) + "\t\t\t", 
+		print "Sending " + name + " = " + str(value) + "\t\t\t", 
 		
+		while not verified and attempts < 3:
 			master.param_set_send(name,value)
 			start = time.time()
 						


### PR DESCRIPTION
Prevent flashPXParameters.py from spamming terminal output by only printing "Sending ...." once per parameter.

Closes #42 