### PR TITLE
vlc: Add vlc.sdp

### DIFF
--- a/br-webui/files/vlc.sdp
+++ b/br-webui/files/vlc.sdp
@@ -1,0 +1,3 @@
+c=IN IP4 127.0.0.1
+m=video 5600 RTP/AVP 96
+a=rtpmap:96 H264/90000

--- a/br-webui/index.js
+++ b/br-webui/index.js
@@ -176,6 +176,10 @@ app.get('/security', function(req, res) {
 	res.render('security', {});
 });
 
+app.get('/vlc.sdp', function (req, res) {
+  var file = __dirname + '/files/vlc.sdp';
+  res.download(file);
+});
 
 app.get('/test', function(req, res) {
 	var module = req.query['module'];


### PR DESCRIPTION
To use it:

    Media -> Open Network Stream -> http://192.168.2.2:2770/vlc.sdp -> play

Fix #60

Signed-off-by: Patrick José Pereira <patrickelectric@gmail.com>