### PR TITLE
Remove navbar form margins, fixing the navbar thickness

### DIFF
--- a/br-webui/style.css
+++ b/br-webui/style.css
@@ -102,3 +102,9 @@ input:checked + .slidernew:before {
 .toggle {
   color: white;
 }
+
+/* removes margins from navbar form so the bar stays thin*/
+.navbar-form {
+  margin-top: 0;
+  margin-bottom: 0;
+}


### PR DESCRIPTION
The Navbar was almost covering the page title:
![deepin-screen-recorder_select area_20181016102414](https://user-images.githubusercontent.com/4013804/47020747-6d77c000-d130-11e8-9bd5-e1aef37a1d3b.gif)
