### PR TITLE
Fix camera settings not working properly.

### DIFF
--- a/br-webui/views/camera.liquid
+++ b/br-webui/views/camera.liquid
@@ -328,10 +328,14 @@
 						option.innerHTML = menuItem;
 						option.value = i;
 						new_element.appendChild(option);
+						if (control.value === i) {
+							// Set selected option to the current one (we can't use 'i' here because empty options are skipped)
+							new_element.selectedIndex = new_element.children.length - 1;
+						}
 					}
 					i = i + 1;
 				});
-				
+
 				new_element.onchange = function(data) {
 					control.value = new_element.value;
 					console.log('set v4l2 control', new_element.name, new_element.id, new_element.value);
@@ -341,7 +345,7 @@
 						value: new_element.value
 					});
 				}
-				new_element.selectedIndex = control.value;
+
 			} else if (control.type == "class") {
 				h5.innerHTML = "";
 				new_element = document.createElement("h4");


### PR DESCRIPTION
It turned out that the issue was that the frontend was not matching the backend for v4l2 'menu' options.

This caused the frontend to display "Manual Mode" while "Aperture Priority Mode" was being used in the backend. This caused the exposure settings to not work unless you switched to "Aperture Priority Mode" and back to "Manual Mode" again, which updated the backend properly.

fix #225 