### PR TITLE
Gstreamer audio options in a file, similarly to the video.

### DIFF
--- a/params/gstreamer2-audio.param.default
+++ b/params/gstreamer2-audio.param.default
@@ -1,0 +1,3 @@
+! audioconvert 
+! rtpL16pay 
+! udpsink host=192.168.2.1 port=5601

--- a/scripts/start_audio.sh
+++ b/scripts/start_audio.sh
@@ -1,6 +1,10 @@
 export LD_LIBRARY_PATH=/usr/local/lib/
+
+# load gstreamer options
+gstOptions=$(tr '\n' ' ' < $HOME/gstreamer2-audio.param)
+
 cd $HOME/
-gst-launch-1.0 -v -e alsasrc device=hw:1,0 ! audioconvert ! rtpL16pay ! udpsink host=192.168.2.1 port=5601
+gst-launch-1.0 -v -e alsasrc device=hw:1,0 $gstOptions
 
 
 #gst-launch-1.0 -v -e alsasrc device=hw:1,0 ! audioconvert ! tcpserversink host=192.168.2.2 port=5700


### PR DESCRIPTION
`start_audio.sh` will use `gstreamer2-audio.param` to load the options, similarly to the video. A default file with the same options in `start_audio.sh` have been created and included in the `param` folder.