### PR TITLE
Fix crash when no orientation is present in DepthOutput output

### DIFF
--- a/tools/underwater-gps.py
+++ b/tools/underwater-gps.py
@@ -243,5 +243,7 @@ while True:
             pass # no data available for udp read
         else:
             print(e)
+    except KeyError as e:
+        print("Warning: error getting a key from MAVProxy/DepthOutput:", e.args[0])
 
     time.sleep(0.02)


### PR DESCRIPTION
This **partially** fixes #265 in the sense that it will not crash. But it is not enough. It will only start working after QGC is opened.
An additional action is needed to force the streams. Could we revert https://github.com/bluerobotics/companion/commit/c2d5ec39d177f103eef98986a9fc031535ce7881?