### PR TITLE
Revert "mavproxy: disable periodic streamrate override"

### DIFF
--- a/params/mavproxy.param.default
+++ b/params/mavproxy.param.default
@@ -6,4 +6,3 @@
 --out udpbcast:192.168.2.255:14550
 --mav20
 --aircraft telemetry
---streamrate -1


### PR DESCRIPTION
This reverts commit c2d5ec39d177f103eef98986a9fc031535ce7881.

fix #273 