### PR TITLE
Add mavlink2rest

### DIFF
--- a/.companion.rc
+++ b/.companion.rc
@@ -29,6 +29,7 @@ if [ ! -f /home/pi/.updating ]; then
 	sudo -H -u pi screen -dm -S nmearx $COMPANION_DIR/tools/nmea-receiver.py
 	sudo -H -u pi screen -dm -S wldriver $COMPANION_DIR/tools/underwater-gps.py --ip=waterlinked.local --port=80
 	sudo -H -u pi screen -dm -S bridgemanager $COMPANION_DIR/tools/ping360_bridge_manager.py
+	sudo -H -u pi screen -dm -S mavlink2rest $COMPANION_DIR/tools/mavlink2rest --connect udpin:127.0.0.1:9002 --server 0.0.0.0:4777
 else
 	sudo -H -u pi echo 'UPDATE FAILED!' >> /home/pi/.update_log
 	rm -f /home/pi/.updating

--- a/params/mavproxy.param.default
+++ b/params/mavproxy.param.default
@@ -3,6 +3,7 @@
 --source-system=200
 --cmd="set heartbeat 0"
 --out udpin:localhost:9000
+--out udpout:localhost:9002
 --out udpin:0.0.0.0:14660
 --out udpbcast:192.168.2.255:14550
 --mav20


### PR DESCRIPTION
Fix #283 

This add a mavlink rest api server running under `http://192.168.2.2:4778/mavlink`