### PR TITLE
companion.rc: Fix if test of default_param_file

### DIFF
--- a/.companion.rc
+++ b/.companion.rc
@@ -1,14 +1,10 @@
 export COMPANION_DIR=/home/pi/companion
 
 # copy default parameters if neccessary
-cd $COMPANION_DIR/params
-
-for default_param_file in *; do
-    if [[ $default_param_file == *".param.default" ]]; then
-        param_file="/home/pi/"$(echo $default_param_file | sed "s/.default//")
-        if [ ! -e "$param_file" ]; then
-            cp $default_param_file $param_file
-        fi
+for default_param_file in $COMPANION_DIR/params/*.param.default; do
+    param_file=/home/pi/$(basename -- $(echo $default_param_file | sed "s/.default//"))
+    if [ ! -e "$param_file" ]; then
+        cp $default_param_file $param_file
     fi
 done
 


### PR DESCRIPTION
Files that are executed by local.rc are executed by dash and not bash,
such thing also applies with shebangs.

This is being fixed moving from string compare "[[ ]]" to a file search.

Signed-off-by: Patrick José Pereira <patrickelectric@gmail.com>