### PR TITLE
.companion.rc: re-enable ping mavlink driver

### DIFF
--- a/.companion.rc
+++ b/.companion.rc
@@ -13,7 +13,7 @@ if [ ! -f /home/pi/.updating ]; then
 	if [ -d /dev/serial/ping ]; then
 		sudo -H -u pi screen -dm -S pingproxy pingproxy.py --device $(ls -d /dev/serial/ping/Ping1* | head -1)
 		# Uncomment the next line to enable Ping1D as a range finder
-		#sudo -H -u pi screen -dm -S pingmav python $COMPANION_DIR/tools/ping1d_mavlink_driver.py
+		sudo -H -u pi screen -dm -S pingmav python $COMPANION_DIR/tools/ping1d_mavlink_driver.py
 	fi
 	sudo -H -u pi screen -dm -S mavproxy $COMPANION_DIR/tools/telem.py
 	sudo -H -u pi screen -dm -S video $COMPANION_DIR/tools/streamer.py 


### PR DESCRIPTION
since https://github.com/ArduPilot/ardupilot/commit/4b16271b3df99991259ffd314acab7bf7635c1a7 we no longer use it for control in depth-hold. Re-enabling it allows users to read the altitude in QGC.

The driver is required to populate the rangefinder fact in qgc:
![Screenshot from 2020-02-20 17-29-18](https://user-images.githubusercontent.com/4013804/74976085-d945f900-5406-11ea-890a-f3711a524c5a.png)
