### PR TITLE
network, index: Move service to run in port 4779

### DIFF
--- a/br-webui/index.js
+++ b/br-webui/index.js
@@ -38,7 +38,7 @@ apiProxy.on('error', function(e) {
 
 // reverse proxy for network
 app.all("/service/network*", function(req, res) {
-	apiProxy.web(req, res, {target: 'http://localhost:9000/'});
+	apiProxy.web(req, res, {target: 'http://localhost:4779/'});
 });
 
 var fs = require("fs");

--- a/services/network/main.py
+++ b/services/network/main.py
@@ -170,4 +170,4 @@ if __name__ == "__main__":
         wifi_manager.set_wifi_password(ssid, password)
         return to_pretty_json(wifi_manager.status())
 
-    bottle.run(host='0.0.0.0', port=9000)
+    bottle.run(host='0.0.0.0', port=4779)


### PR DESCRIPTION
The port 9000 is now used in mavproxy

Signed-off-by: Patrick José Pereira <patrickelectric@gmail.com>