### PR TITLE
br-webui: index: Fix backslash in find command

### DIFF
--- a/br-webui/index.js
+++ b/br-webui/index.js
@@ -1268,7 +1268,7 @@ io.on('connection', function(socket) {
 	socket.on('get companion latest', function(data) {
 		logger.log("get companion latest");
 		// Find and remove any lost git .lock file and check if we are in the stable tag
-		var cmd = child_process.exec('find "$(git rev-parse --show-toplevel)/.git" -name "*\.lock" -exec rm -f {} \;; git tag -d stable >/dev/null; git fetch --tags >/dev/null; git rev-list --left-right --count HEAD...refs/tags/stable | cut -f2', function(error, stdout, stderr) {
+		var cmd = child_process.exec('find "$(git rev-parse --show-toplevel)/.git" -name "*\.lock" -exec rm -f {} \\;; git tag -d stable >/dev/null; git fetch --tags >/dev/null; git rev-list --left-right --count HEAD...refs/tags/stable | cut -f2', function(error, stdout, stderr) {
 			logger.log(error + stdout + stderr);
 			if (parseInt(stdout) > 0) {
 				socket.emit('companion latest');


### PR DESCRIPTION
How to test:

- Check if there is a lock file:
    `find ~/companion/.git | grep lock`
- Create a lock file if it does not exist:
    `touch ~/companion/.git/refs/tags/stable.lock`
- Go in: http://192.168.2.2:2770/system or hit F5 in this webpage
- The file will not exist anymore

Signed-off-by: Patrick José Pereira <patrickelectric@gmail.com>