### PR TITLE
tools: Update mavlink2rest to version 0.7.4

### DIFF
--- a/.companion.rc
+++ b/.companion.rc
@@ -24,7 +24,7 @@ if [ ! -f /home/pi/.updating ]; then
 	sudo -H -u pi screen -dm -S nmearx $COMPANION_DIR/tools/nmea-receiver.py
 	sudo -H -u pi screen -dm -S wldriver $COMPANION_DIR/tools/underwater-gps.py --ip=waterlinked.local --port=80
 	sudo -H -u pi screen -dm -S bridgemanager $COMPANION_DIR/tools/ping360_bridge_manager.py
-	sudo -H -u pi screen -dm -S mavlink2rest $COMPANION_DIR/tools/mavlink2rest --connect udpin:127.0.0.1:9002 --server 0.0.0.0:4777
+	sudo -H -u pi screen -dm -S mavlink2rest $COMPANION_DIR/tools/mavlink2rest --connect udpin:127.0.0.1:9002 --server 0.0.0.0:4777 --system-id 1 --component-id 99
 	sudo -H -u root screen -dm -S network-service $COMPANION_DIR/services/network/main.py
 	$COMPANION_DIR/scripts/start-ardusub-linux.sh || true
 else


### PR DESCRIPTION
Fix #403, uses a system and component ID different from the GCS to avoid problems with the failsafe mechanism when communication with the real GCS is lost. 